### PR TITLE
fix:修复QGIS的nativeAddField以及nativeAddXYField算子参数输入，更改矢量算子结果的落地路径

### DIFF
--- a/src/main/scala/whu/edu/cn/oge/Feature.scala
+++ b/src/main/scala/whu/edu/cn/oge/Feature.scala
@@ -526,6 +526,18 @@ object Feature {
     // 关闭PrintWriter
     writer.close()
 
+    try {
+      versouSshUtil("10.101.240.10", "root", "ypfamily", 22)
+      val st =
+        raw"""scp "$outputVectorPath" root@10.101.240.10:/home/oge/tomcat/apache-tomcat-9.0.80/webapps/oge_vector/""".stripMargin
+      println(s"st = $st")
+      runCmd(st, "UTF-8")
+
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+    }
+
     val storageURL = "http://10.101.240.10:8679/oge_vector/vector_" + time + ".json"
     storageURL
   }

--- a/src/main/scala/whu/edu/cn/oge/QGIS.scala
+++ b/src/main/scala/whu/edu/cn/oge/QGIS.scala
@@ -232,7 +232,7 @@ object QGIS {
                      input: RDD[(String, (Geometry, mutable.Map[String, Any]))],
                      fieldType: String = "0",
                      fieldPrecision: Double = 0,
-                     fieldName: String = "",
+                     fieldName: String = "default",
                      fieldLength: Double = 10):
   RDD[(String, (Geometry, mutable.Map[String, Any]))] = {
 
@@ -271,7 +271,7 @@ object QGIS {
   def nativeAddXYField(implicit sc: SparkContext,
                        input: RDD[(String, (Geometry, mutable.Map[String, Any]))],
                        crs: String = "EPSG:4326",
-                       prefix: String = ""):
+                       prefix: String = "default"):
   RDD[(String, (Geometry, mutable.Map[String, Any]))] = {
 
     val time = System.currentTimeMillis()
@@ -413,7 +413,7 @@ object QGIS {
     try {
       versouSshUtil("10.101.240.10", "root", "ypfamily", 22)
       val st =
-        raw"""conda activate qgis;cd /home/geocube/oge/oge-server/dag-boot/qgis;python algorithmCodeByQGIS/native_affinetransform.py --input "$outputTiffPath" --segments $segments --join-style "$joinStyle" --offset $offset --count $count --miter-limit $miterLimit --output "$writePath"""".stripMargin
+        raw"""conda activate qgis;cd /home/geocube/oge/oge-server/dag-boot/qgis;python algorithmCodeByQGIS/native_arrayoffsetlines.py --input "$outputTiffPath" --segments $segments --join-style "$joinStyle" --offset $offset --count $count --miter-limit $miterLimit --output "$writePath"""".stripMargin
 
       println(s"st = $st")
       runCmd(st, "UTF-8")
@@ -908,7 +908,7 @@ object QGIS {
    */
   def nativeTransect(implicit sc: SparkContext,
                      input: RDD[(String, (Geometry, mutable.Map[String, Any]))],
-                     side: String = "",
+                     side: String = "2",
                      length: Double = 5.0,
                      angle: Double = 90.0):
   RDD[(String, (Geometry, mutable.Map[String, Any]))] = {


### PR DESCRIPTION
fix:修复QGIS的nativeAddField以及nativeAddXYField算子参数输入，更改矢量算子结果的落地路径