### PR TITLE
fix:解决QGIS算子参数类型不匹配的问题

### DIFF
--- a/src/main/scala/whu/edu/cn/jsonparser/algorithms.json
+++ b/src/main/scala/whu/edu/cn/jsonparser/algorithms.json
@@ -4039,7 +4039,7 @@
       },
       {
         "name": "extent",
-        "type": "String",
+        "type": "Feature",
         "description": "Defines the bounding box that should be used for the output vector file. It has to be defined in target CRS coordinates.",
         "optional": "True",
         "default": ""
@@ -4064,7 +4064,7 @@
       },
       {
         "name": "mask",
-        "type": "String",
+        "type": "Feature",
         "description": "Layer to be used as clipping extent for the input vector layer.",
         "optional": "True",
         "default": ""

--- a/src/main/scala/whu/edu/cn/jsonparser/algorithms_ogc.json
+++ b/src/main/scala/whu/edu/cn/jsonparser/algorithms_ogc.json
@@ -4071,7 +4071,7 @@
       },
       {
         "name": "extent",
-        "type": "String",
+        "type": "Feature",
         "description": "Defines the bounding box that should be used for the output vector file. It has to be defined in target CRS coordinates.",
         "optional": "True",
         "default": ""
@@ -4096,7 +4096,7 @@
       },
       {
         "name": "mask",
-        "type": "String",
+        "type": "Feature",
         "description": "Layer to be used as clipping extent for the input vector layer.",
         "optional": "True",
         "default": ""

--- a/src/main/scala/whu/edu/cn/trigger/Trigger.scala
+++ b/src/main/scala/whu/edu/cn/trigger/Trigger.scala
@@ -547,9 +547,9 @@ object Trigger {
         case "Feature.dissolveByGDAL" =>
           featureRddList += (UUID -> QGIS.gdalDissolve(sc, featureRddList(args("input")).asInstanceOf[RDD[(String, (Geometry, mutable.Map[String, Any]))]], explodeCollections = args("explodeCollections"), field = args("field"), computeArea = args("computeArea"), keepAttributes = args("keepAttributes"), computeStatistics = args("computeStatistics"), countFeatures = args("countFeatures"), statisticsAttribute = args("statisticsAttribute"), options = args("options"), geometry = args("geometry")))
         case "Feature.clipVectorByExtentByGDAL" =>
-          featureRddList += (UUID -> QGIS.gdalClipVectorByExtent(sc, featureRddList(args("input")).asInstanceOf[RDD[(String, (Geometry, mutable.Map[String, Any]))]], extent = args("extent"), options = args("options")))
+          featureRddList += (UUID -> QGIS.gdalClipVectorByExtent(sc, featureRddList(args("input")).asInstanceOf[RDD[(String, (Geometry, mutable.Map[String, Any]))]], extent = featureRddList(args("extent")).asInstanceOf[RDD[(String, (Geometry, mutable.Map[String, Any]))]], options = args("options")))
         case "Feature.clipVectorByPolygonByGDAL" =>
-          featureRddList += (UUID -> QGIS.gdalClipVectorByPolygon(sc, featureRddList(args("input")).asInstanceOf[RDD[(String, (Geometry, mutable.Map[String, Any]))]], mask = args("mask"), options = args("options")))
+          featureRddList += (UUID -> QGIS.gdalClipVectorByPolygon(sc, featureRddList(args("input")).asInstanceOf[RDD[(String, (Geometry, mutable.Map[String, Any]))]], mask = featureRddList(args("mask")).asInstanceOf[RDD[(String, (Geometry, mutable.Map[String, Any]))]], options = args("options")))
         case "Feature.offsetCurveByGDAL" =>
           featureRddList += (UUID -> QGIS.gdalOffsetCurve(sc, featureRddList(args("input")).asInstanceOf[RDD[(String, (Geometry, mutable.Map[String, Any]))]], distance = args("distance").toDouble, geometry = args("geometry"), options = args("options")))
         case "Feature.pointsAlongLinesByGDAL" =>


### PR DESCRIPTION
fix:解决Feature.clipVectorByExtentByGDAL以及Feature.clipVectorByPolygonByGDAL算子参数类型不匹配的问题